### PR TITLE
Do not decode bytes to string by default

### DIFF
--- a/src/zed/__init__.py
+++ b/src/zed/__init__.py
@@ -217,12 +217,6 @@ class ZmqSocket(object):
                     continue
                 
                 raise e
-            
-            # PY3: With Python2 version of pyzmq, `recv_multipart` returned list of strings.
-            # However, with Python3 update of pyzmq, `recv_multipart` now returns list of raw bytes.
-            # To maintain compatibility, we decode incoming bytes and return list of strings to
-            # the client as before.
-            msg_list = [m.decode() if isinstance(m, bytes) else m for m in msg_list]
             log.callWithLogger(self, self.messageReceived, msg_list)
                 
 


### PR DESCRIPTION
Hi Tom,

I am reverting a change that i added recently. Here is my reasoning - 

It's an incorrect assumption to make that the incoming bytes will always be of type string. What if the client has actually sent an int, or a float or an image file that can’t be decoded to string?

The current logic will work fine for clients talking only in terms of strings. But it won’t work otherwise. It’s not a good idea to have this logic coded in a generic library. Let’s leave it up to the client to decode the bytes to the appropriate type as they see fit.

I think its ok to keep the logic of encoding strings to bytes while sending data because that's a reasonable assumption. But the reverse is not true. Let me know what you think. 



